### PR TITLE
86cwyg25e - Add function get bulk product variant

### DIFF
--- a/test/product/product_test.go
+++ b/test/product/product_test.go
@@ -19,6 +19,7 @@ const (
 	TestSingleQueryProductID = "gid://shopify/Product/8427241144634"
 	TestProductVariantCount  = 72
 	TestProductMediaCount    = 6
+	PrefixProductShopify     = "gid://shopify/Product/"
 )
 
 var _ = Describe("ProductService", func() {
@@ -52,7 +53,7 @@ var _ = Describe("ProductService", func() {
 					Expect(results[i].Handle).NotTo(BeEmpty())
 					Expect(results[i].Images).NotTo(BeNil())
 					Expect(results[i].Media).NotTo(BeNil())
-					Expect(results[i].Variants).NotTo(BeNil())
+					Expect(results[i].Variants).To(BeNil())
 					Expect(results[i].CreatedAt).NotTo(BeZero())
 				}
 			})
@@ -74,7 +75,7 @@ var _ = Describe("ProductService", func() {
 					Expect(results[i].Handle).NotTo(BeEmpty())
 					Expect(results[i].Images).NotTo(BeNil())
 					Expect(results[i].Media).NotTo(BeNil())
-					Expect(results[i].Variants).NotTo(BeNil())
+					Expect(results[i].Variants).To(BeNil())
 					Expect(results[i].CreatedAt).NotTo(BeZero())
 				}
 			})
@@ -171,7 +172,18 @@ var _ = Describe("ProductService", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(product).NotTo(BeNil())
 				Expect(product.ID).To(Equal(TestSingleQueryProductID))
-				Expect(len(product.Variants.Edges)).To(Equal(TestProductVariantCount))
+				Expect(product.VariantsCount.Count).To(Equal(TestProductVariantCount))
+			})
+		})
+	})
+
+	Describe("Count variants", func() {
+		When("Count variants", func() {
+			It("can return number of variants", func() {
+				query := fmt.Sprintf("product_id:%s", strings.ReplaceAll(TestSingleQueryProductID, PrefixProductShopify, ""))
+				productVariant, err := shopifyClient.Product.ListVariants(ctx, shopify.WithQuery(query))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(productVariant)).To(Equal(TestProductVariantCount))
 			})
 		})
 	})


### PR DESCRIPTION
## What are changes? (optional)
- Add function get bulk product variant
- Add count variant when getting product
- Remove get variant when getting product

## Tests results (required)
```bash
go vet ./...
go clean -testcache
MODE=test go test -cover -race -ldflags=-extldflags=-Wl,-ld_classic /Users/levankhanh/Workspace/go/src/GEM/go-shopify-graphql/test/product/product_suit_test.go
ok      command-line-arguments  1.463s  coverage: [no statements]

```

